### PR TITLE
Strip the whitespace from client-id.txt so its easier to create.

### DIFF
--- a/rechat-dl.py
+++ b/rechat-dl.py
@@ -23,7 +23,7 @@ if len(sys.argv) < 2 or len(sys.argv) > 3:
 
 cid = None
 with open(os.path.join(os.path.dirname(__file__), 'client-id.txt')) as cidf:
-    cid = cidf.read()
+    cid = cidf.read().strip()
     
     if cid.startswith("("):
         sys.exit("The Client-ID needs to be set! Edit the 'client-id.txt' file in this folder to set it.")


### PR DESCRIPTION
Some editors make it tricky to create a file without trailing whitespace, such as vi(m). But the contents of client-id.txt never need to contain any whitespace. Strip the contents before sending an authenticated request.